### PR TITLE
fix: moved lock_init into syscall_init

### DIFF
--- a/userprog/syscall.c
+++ b/userprog/syscall.c
@@ -35,10 +35,12 @@ void syscall_init(void)
 {
     write_msr(MSR_STAR, ((uint64_t)SEL_UCSEG - 0x10) << 48 | ((uint64_t)SEL_KCSEG) << 32);
     write_msr(MSR_LSTAR, (uint64_t)syscall_entry);
+    
     /* The interrupt service rountine should not serve any interrupts
      * until the syscall_entry swaps the userland stack to the kernel
      * mode stack. Therefore, we masked the FLAG_FL. */
     write_msr(MSR_SYSCALL_MASK, FLAG_IF | FLAG_TF | FLAG_DF | FLAG_IOPL | FLAG_AC | FLAG_NT);
+    lock_init(&lock);
 }
 
 /* The main system call interface */
@@ -53,7 +55,6 @@ void syscall_handler(struct intr_frame* f UNUSED)
     uint64_t arg5 = f->R.r8;
     uint64_t arg6 = f->R.r9;
 
-    lock_init(&lock);
 
     switch (syscall_num) {
 


### PR DESCRIPTION
## 변경 사항
### 핵심 구현
- lock_init 위치 옮기기

### 변경 파일
- ```syscall.c```
  - lock_init 함수 위치를 syscall_init으로 옮김
  - 이렇게 하지 않으면 syscall_handler가 호출될 때 마다 lock이 initialize 되어 비효율적임

## 체크리스트
- [ x] 커밋 메시지 컨벤션 준수
- [ x] 불필요한 주석 및 코드 제거
- [ x] 하위 테스트 목록 통과 여부
  - args-none
  - args-single
  - args-multiple
  - args-many
  - args-dbl-space
  - exit


## 부가 전달 내용
