### PR TITLE
fix: check_valid_ptr func 검증 순서 분리

### DIFF
--- a/userprog/syscall.c
+++ b/userprog/syscall.c
@@ -137,13 +137,13 @@ static void check_valid_ptr(int count, ...)
         uint64_t ptr = va_arg(ptr_ap, uint64_t);
 
         // Check NULL
-        if (!ptr) {
+        if (ptr == NULL) {
             va_end(ptr_ap);
             exit(-1);
         }
 
         // Check user segment
-        if (ptr < CODE_SEGMENT || ptr > USER_STACK) {
+        if (ptr < CODE_SEGMENT || ptr >= USER_STACK) {
             va_end(ptr_ap);
             exit(-1);
         }


### PR DESCRIPTION
## 변경 사항
### 핵심 구현
- check_valid_ptr 함수 검증 로직 분리

### 변경 파일
- ```userprog/syscall.c```
  - ```NULL``` 체크 로직 포함
  - 유저 세그먼트와 메모리 할당 검증 로직을 분리하고 검증 순서 고정

## 체크리스트
- [x] 커밋 메시지 컨벤션 준수
- [x] 불필요한 주석 및 코드 제거
- [x] 하위 테스트 목록 통과 여부

## 부가 전달 내용
