### PR TITLE
fix: github action에 write기능 추가한 PAT 등록

### DIFF
--- a/.github/workflows/pr-cicd.yml
+++ b/.github/workflows/pr-cicd.yml
@@ -8,6 +8,8 @@ on:
 jobs:
   test:
     runs-on: ubuntu-22.04
+    env:
+      MY_PAT: ${{ secrets.JG3TEAMPINTOS12W }}
     timeout-minutes: 60
     permissions:
       contents: read
@@ -140,6 +142,7 @@ jobs:
         uses: peter-evans/find-comment@v3
         id: find-comment
         with:
+          token: ${{ env.MY_PAT }}
           issue-number: ${{ github.event.pull_request.number }}
           comment-author: "github-actions[bot]"
           body-includes: "🚀 Pintos CI Report"
@@ -147,6 +150,7 @@ jobs:
       - name: Create or update PR comment
         uses: peter-evans/create-or-update-comment@v4
         with:
+          token: ${{ env.MY_PAT }}
           comment-id: ${{ steps.find-comment.outputs.comment-id }}
           issue-number: ${{ github.event.pull_request.number }}
           body-path: test-summary.md
@@ -156,6 +160,7 @@ jobs:
         if: always()
         uses: actions/upload-artifact@v4
         with:
+          token: ${{ env.MY_PAT }}
           name: pintos-test-results
           path: |
             */build/tests/**/*.output


### PR DESCRIPTION
fork 한 원격저장소에서도 github action 사용 가능

## 변경 사항
### 핵심 구현
- 기존 github action에 PAT 토큰 등록
    - fork한 원격 저장소에서도 action 사용 가능
- 테스트 완료!!

### 변경 파일
- `.github/workflows/pr-cicd.yml`

## 체크리스트
- [x] 커밋 메시지 컨벤션 준수
- [x] 불필요한 주석 및 코드 제거
- [x] 테스트 통과 여부

## 부가 전달 내용
