### PR TITLE
feat: SPT 자료구조 변경 (Linked List -> Hash Table)

### DIFF
--- a/include/vm/vm.h
+++ b/include/vm/vm.h
@@ -3,6 +3,7 @@
 #include <stdbool.h>
 #include "threads/palloc.h"
 #include "list.h"
+#include <hash.h>
 
 enum vm_type {
     /* page not initialized */
@@ -51,7 +52,7 @@ struct page {
     const struct page_operations* operations;
     void* va;              /* Address in terms of user space */
     struct frame* frame;   /* Back reference for frame */
-    struct list_elem elem; // 연결리스트로 사용할 elem
+    struct hash_elem elem; // SPT entry
     bool writable;         // page구조체에 상태,타입,...등
     enum vm_type type;
 
@@ -96,7 +97,7 @@ struct page_operations {
  * We don't want to force you to obey any specific design for this struct.
  * All designs up to you for this. */
 struct supplemental_page_table {
-    struct list pages; // page 연결리스트
+    struct hash pages;
 };
 
 #include "threads/thread.h"

--- a/vm/vm.c
+++ b/vm/vm.c
@@ -136,6 +136,7 @@ bool spt_insert_page(struct supplemental_page_table* spt, struct page* page)
     ASSERT(page != NULL);
     ASSERT(page->va != NULL);
     hash_insert(&spt->pages, &page->elem);
+    ASSERT(hash_find(&spt->pages, &page->elem) == &page->elem)
     // TODO:: `hash_insert` 함수는 동일한 element가 이미 존재하면 기존 element를 리턴한다.
     // 이 경우에 대한 예외처리가 필요하다.
 

--- a/vm/vm.c
+++ b/vm/vm.c
@@ -136,6 +136,8 @@ bool spt_insert_page(struct supplemental_page_table* spt, struct page* page)
     ASSERT(page != NULL);
     ASSERT(page->va != NULL);
     hash_insert(&spt->pages, &page->elem);
+    // TODO:: `hash_insert` 함수는 동일한 element가 이미 존재하면 기존 element를 리턴한다.
+    // 이 경우에 대한 예외처리가 필요하다.
 
     return true;
 }


### PR DESCRIPTION
## 변경 사항
### 핵심 구현
- SPT의 자료구조를 linked list에서 hash table로 변경

### 변경 파일

- `include/vm/vm.h` |  5 +--                   

    - hashing 함수 원형 선언
    - chaining(해시 충돌 대응) 할 때 위치 잡는 함수 원형 선언


- `vm/vm.c`         | 39 ++++++++++++++++------

    - 기존 Linked List 자료구조를 hash table 구조로 변경
        - hashing 함수 정의
        - chaining(해시 충돌 대응) 할 때 위치 잡는 함수 정의

    - page fault를 발생시킨 가상주로로 접근하여 SPT entry 찾기



## 체크리스트
- [x] 커밋 메시지 컨벤션 준수
- [x] 불필요한 주석 및 코드 제거
- [x] 테스트 통과 여부
